### PR TITLE
Fixed additional typos and formatting in specification

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1440,7 +1440,7 @@ Some features of this specification, such as contrast control, overlap with capa
 
 ### CSS format ### {#css_format}
 
-CSS defines its own syntax, processing model, and format, initially define in the 1990s. It requires a custom processor.
+CSS defines its own syntax, processing model, and format, initially defined in the 1990s. It requires a custom processor.
 
 This specification uses the common JSON format, which can be processed by any JSON tools, including web browser contexts, JavaScript, and many other tools.
 

--- a/index.bs
+++ b/index.bs
@@ -249,7 +249,7 @@ Structured data includes faceted data, whether qualitative or quantitative, that
 
 This data must be included in objects in the `facets` and `series` keys.
 
-Note: A future version of this specification will define schamata for a canonical dataset structure or set of structures for different types of data visualization.
+Note: A future version of this specification will define schemata for a canonical dataset structure or set of structures for different types of data visualization.
 
 #### Unstructured data #### {#unstructured_data}
 
@@ -1086,7 +1086,7 @@ Each capability defines an array of capability instances, each of which consists
 </xmp>
 
 <div class="note">
-<b>Note:</b> Consider splitting out capabilities and ratings into seperate entries.
+<b>Note:</b> Consider splitting out capabilities and ratings into separate entries.
 </div>
 
 <div class="note">

--- a/index.bs
+++ b/index.bs
@@ -50,9 +50,9 @@ This specification should be complete and definitive with the state of the art, 
 
 ## Personalization ## {#personalization}
 
-This assistive technology must enable the user to select which of the available accomodations are enabled at any time, and at which available effect level. This must be able to set as a default in the user agent, and must be overrideable by the user to meet their specific need at any time.
+This assistive technology must enable the user to select which of the available accommodations are enabled at any time, and at which available effect level. This must be able to set as a default in the user agent, and must be overrideable by the user to meet their specific need at any time.
 
-Any given end-user might have multiple disabilities, with varying degrees of effect at any given time; any given document might have multiple accomodations enabled and encoded in it; any given user agent might suport multiple assistive technologies; any given environment might have different affordances and constraints.
+Any given end-user might have multiple disabilities, with varying degrees of effect at any given time; any given document might have multiple accommodations enabled and encoded in it; any given user agent might suport multiple assistive technologies; any given environment might have different affordances and constraints.
 
 <div id='xmp_low_vision_high_contrast' class='example'>
 A low vision user might wish to enable very high contrast in a bright environment or when they are tired, and lower contrast when they are in a more moderately lighted environment and well-rested.
@@ -96,7 +96,7 @@ At the same time, this specification should establish defaults and baselines bas
 
 ## Searching and categorization ## {#searching_categorization}
 
-This specification must define easy ways to enable the distribution and discovery of content based on user needs and accomodation provided in the document. One way to do this is to provide a standardized way to express keyword tags, ratings, and capabilities within the document itself.
+This specification must define easy ways to enable the distribution and discovery of content based on user needs and accommodation provided in the document. One way to do this is to provide a standardized way to express keyword tags, ratings, and capabilities within the document itself.
 
 ## Provenance expression ## {#provenance_expression}
 
@@ -1051,7 +1051,7 @@ The `keywords` key denotes an array of user-defined strings. Examples of keyword
 <b>Note:</b> This is a rough notion of how we might define
 </div>
 
-The `capabilities` key denotes an object that includes which accomodations have been defined in the image document, and some system of rating that scores the effectiveness of that accomodation.
+The `capabilities` key denotes an object that includes which accommodations have been defined in the image document, and some system of rating that scores the effectiveness of that accommodation.
 
 Each capability defines an array of capability instances, each of which consists of a least a condition of applicability, and a rating.
 

--- a/index.bs
+++ b/index.bs
@@ -352,14 +352,14 @@ An example of a `datasets` block (with elided values) for a structured data repr
   "description": "",
   "representation": {
   },
-  "facets": [
-  ],
+  "facets": {
+  },
   "series": [
   ],
   "source": {
   },
-  "href": [
-  ]
+  "href": {
+  }
 }
 </xmp>
 </div>

--- a/index.bs
+++ b/index.bs
@@ -1170,7 +1170,7 @@ A region describing a circular area with a centerpoint at `100, 121` and a radiu
 </div>
 
 <div id='xmp_region_shape_complex' class='example'>
-A region describing a irregular area using the `path` definition and a rectangle definition, which together make a single region. The rectangle definition elides the "x" attribute, which defaults to `0`, per the SVG 2 specification.
+A region describing an irregular area using the `path` definition and a rectangle definition, which together make a single region. The rectangle definition elides the "x" attribute, which defaults to `0`, per the SVG 2 specification.
 
 <xmp highlight='json'>
 {

--- a/index.bs
+++ b/index.bs
@@ -1190,8 +1190,11 @@ A region describing an irregular area using the `path` definition and a rectangl
 </xmp>
 </div>
 
-For each shape definition, a conforming implementation must instantiate a corresponding shape matching the element type and attributes 
-Similar to your implementation, there will indeed be the ability to draw “invisible shapes” over areas of the image. This can be used to create larger hit-detection targets for small or fragmented graphical elements, to “group” things, to provide precision for overlaps, to create overlays for raster images that aren’t vectorized, or for any other purpose where you don’t want to rely on the native SVG hit detection for the graphical element. This behavior is already in the spec, though I need to explain the rationale. The intention is that these hidden shapes would not have to be part of the SVG itself, but are defined in the JSON metadata, and the user agent would dynamically generate these and insert them into the DOM; this keeps the SVG itself clean.
+For each shape definition, a conforming implementation must instantiate a corresponding shape matching the element type and attributes.
+
+<div class="note">
+<b>Note:</b> Similar to your implementation, there will indeed be the ability to draw “invisible shapes” over areas of the image. This can be used to create larger hit-detection targets for small or fragmented graphical elements, to “group” things, to provide precision for overlaps, to create overlays for raster images that aren’t vectorized, or for any other purpose where you don’t want to rely on the native SVG hit detection for the graphical element. This behavior is already in the spec, though I need to explain the rationale. The intention is that these hidden shapes would not have to be part of the SVG itself, but are defined in the JSON metadata, and the user agent would dynamically generate these and insert them into the DOM; this keeps the SVG itself clean.
+</div>
 
 # Haptics # {#haptics_behavior}
 ## Haptic patterns ## {#haptic_patterns}

--- a/index.bs
+++ b/index.bs
@@ -1238,7 +1238,7 @@ A complex haptic pattern that will trigger a sequence of vibrations 10 milliseco
 </xmp>
 </div>
 
-> **Note:** The W3C Vibration API defines only a simple non-repeating sequence of durations. This specification extends that with an optional additional value for repetition of that pattern with a fixed interval between pattern instances, and an optional repetiion index. 
+> **Note:** The W3C Vibration API defines only a simple non-repeating sequence of durations. This specification extends that with an optional additional value for repetition of that pattern with a fixed interval between pattern instances, and an optional repetition index. 
 
 <!-- This specification does not currently add capabilities for defining intensity, target region, or other haptic qualities, due to limitations in the W3C Vibration API and device capabilities. -->
 

--- a/index.bs
+++ b/index.bs
@@ -1101,7 +1101,7 @@ A region is an area of an diagram image that is associated with a particular beh
 Regions may consist of one of two possible values:
 
 1. **An element link**: a selector indicating a specific element or set of elements in the DOM of a SVG file;
-2. **A `shape` object**: an object that defines a shape to be dynamically represented in the diagram file.
+2. **A** `shape` **object**: an object that defines a shape to be dynamically represented in the diagram file.
 
 ## Region element `selector` ## {#region_element_selector}
 

--- a/index.html
+++ b/index.html
@@ -1491,7 +1491,7 @@ Possible extra rowspan handling
   <meta content="Bikeshed version 742f3d674, updated Mon Nov 4 14:56:54 2024 -0800" name="generator">
   <link href="https://Inclusio-Community.github.io/json-image-metadata/" rel="canonical">
   <link href="./favicon.svg" rel="icon">
-  <meta content="e75f2917735f228c446d17bd871e43062007ea35" name="revision">
+  <meta content="e7a845b02d1dc10f7812adeaf8a1b15c1e62ffd5" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>/* Boilerplate: style-autolinks */
 .css.css, .property.property, .descriptor.descriptor {
@@ -2016,7 +2016,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">JSON Image Metadata</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2024-11-11">11 November 2024</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2024-11-13">13 November 2024</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2030,7 +2030,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <div data-fill-with="warning"></div>
    <p class="copyright" data-fill-with="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" height="15" src="https://licensebuttons.net/p/zero/1.0/80x15.png" width="80"></a> To the extent possible under law, the editors have waived all copyright
 and related or neighboring rights to this work.
-In addition, as of 11 November 2024,
+In addition, as of 13 November 2024,
 the editors have made this specification available under the <a href="https://www.openwebfoundation.org/the-agreements/the-owf-1-0-agreements-granted-claims/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
 which is available at https://www.openwebfoundation.org/the-agreements/the-owf-1-0-agreements-granted-claims/owfa-1-0.
 Parts of this work may be from another specification document.  If so, those parts are instead covered by the license of that specification document. </p>
@@ -2450,14 +2450,14 @@ Parts of this work may be from another specification document.  If so, those par
   <c- f>"description"</c-><c- p>:</c-> <c- u>""</c-><c- p>,</c->
   <c- f>"representation"</c-><c- p>:</c-> <c- p>{</c->
   <c- p>},</c->
-  <c- f>"facets"</c-><c- p>:</c-> <c- p>[</c->
-  <c- p>],</c->
+  <c- f>"facets"</c-><c- p>:</c-> <c- p>{</c->
+  <c- p>},</c->
   <c- f>"series"</c-><c- p>:</c-> <c- p>[</c->
   <c- p>],</c->
   <c- f>"source"</c-><c- p>:</c-> <c- p>{</c->
   <c- p>},</c->
-  <c- f>"href"</c-><c- p>:</c-> <c- p>[</c->
-  <c- p>]</c->
+  <c- f>"href"</c-><c- p>:</c-> <c- p>{</c->
+  <c- p>}</c->
 <c- p>}</c->
 </pre>
    </div>
@@ -3000,7 +3000,7 @@ Parts of this work may be from another specification document.  If so, those par
 </pre>
    </div>
    <div class="example" id="xmp_region_shape_complex">
-    <a class="self-link" href="#xmp_region_shape_complex"></a> A region describing a irregular area using the <code>path</code> definition and a rectangle definition, which together make a single region. The rectangle definition elides the "x" attribute, which defaults to <code>0</code>, per the SVG 2 specification. 
+    <a class="self-link" href="#xmp_region_shape_complex"></a> A region describing an irregular area using the <code>path</code> definition and a rectangle definition, which together make a single region. The rectangle definition elides the "x" attribute, which defaults to <code>0</code>, per the SVG 2 specification. 
 <pre class="highlight"><c- p>{</c->
   <c- f>"region"</c-><c- p>:</c-> <c- p>{</c->
     <c- f>"shape"</c-><c- p>:</c-> <c- p>{</c->
@@ -3017,8 +3017,8 @@ Parts of this work may be from another specification document.  If so, those par
 <c- p>}</c->
 </pre>
    </div>
-   <p>For each shape definition, a conforming implementation must instantiate a corresponding shape matching the element type and attributes
-Similar to your implementation, there will indeed be the ability to draw “invisible shapes” over areas of the image. This can be used to create larger hit-detection targets for small or fragmented graphical elements, to “group” things, to provide precision for overlaps, to create overlays for raster images that aren’t vectorized, or for any other purpose where you don’t want to rely on the native SVG hit detection for the graphical element. This behavior is already in the spec, though I need to explain the rationale. The intention is that these hidden shapes would not have to be part of the SVG itself, but are defined in the JSON metadata, and the user agent would dynamically generate these and insert them into the DOM; this keeps the SVG itself clean.</p>
+   <p>For each shape definition, a conforming implementation must instantiate a corresponding shape matching the element type and attributes.</p>
+   <div class="note" role="note"> <b>Note:</b> Similar to your implementation, there will indeed be the ability to draw “invisible shapes” over areas of the image. This can be used to create larger hit-detection targets for small or fragmented graphical elements, to “group” things, to provide precision for overlaps, to create overlays for raster images that aren’t vectorized, or for any other purpose where you don’t want to rely on the native SVG hit detection for the graphical element. This behavior is already in the spec, though I need to explain the rationale. The intention is that these hidden shapes would not have to be part of the SVG itself, but are defined in the JSON metadata, and the user agent would dynamically generate these and insert them into the DOM; this keeps the SVG itself clean. </div>
    <h2 class="heading settled" data-level="6" id="haptics_behavior"><span class="secno">6. </span><span class="content">Haptics</span><a class="self-link" href="#haptics_behavior"></a></h2>
    <h3 class="heading settled" data-level="6.1" id="haptic_patterns"><span class="secno">6.1. </span><span class="content">Haptic patterns</span><a class="self-link" href="#haptic_patterns"></a></h3>
    <p>A haptic pattern, denoted by a <code>haptic_pattern</code> key, is a string consisting of 3 comma-or-space-separated parameters defining a sequence of vibration durations. The sequence of durations is an array of integers describing an alternating pattern of vibrations and pauses, starting with an initial pause before the first vibration starts.</p>
@@ -3056,7 +3056,7 @@ Similar to your implementation, there will indeed be the ability to draw “invi
 </pre>
    </div>
    <blockquote>
-    <p><strong>Note:</strong> The W3C Vibration API defines only a simple non-repeating sequence of durations. This specification extends that with an optional additional value for repetition of that pattern with a fixed interval between pattern instances, and an optional repetiion index.</p>
+    <p><strong>Note:</strong> The W3C Vibration API defines only a simple non-repeating sequence of durations. This specification extends that with an optional additional value for repetition of that pattern with a fixed interval between pattern instances, and an optional repetition index.</p>
    </blockquote>
    <h3 class="heading settled" data-level="6.2" id="amplitude_patterns"><span class="secno">6.2. </span><span class="content">Amplitude patterns</span><a class="self-link" href="#amplitude_patterns"></a></h3>
    <p>A amplitude pattern, denoted by a <code>amplitude_pattern</code> key, is a string consisting of 1 parameter defining a sequence of vibration amplitudes that correspond to the <code>haptic_pattern</code> vibration duration array. The sequence of amplitudes is an array of integers describing an alternating pattern of vibration amplitudes and pauses, indexed to the same sequence as the <code>haptic_pattern</code> vibration duration array.</p>
@@ -3203,7 +3203,7 @@ Similar to your implementation, there will indeed be the ability to draw “invi
    <h3 class="heading settled" data-level="9.2" id="css"><span class="secno">9.2. </span><span class="content">Cascading Style Sheets (CSS)</span><a class="self-link" href="#css"></a></h3>
    <p>Some features of this specification, such as contrast control, overlap with capabilities of CSS, such as the <code>prefers-high-contrast</code> media query. This specification is designed to complement and extend such capabilities.</p>
    <h4 class="heading settled" data-level="9.2.1" id="css_format"><span class="secno">9.2.1. </span><span class="content">CSS format</span><a class="self-link" href="#css_format"></a></h4>
-   <p>CSS defines its own syntax, processing model, and format, initially define in the 1990s. It requires a custom processor.</p>
+   <p>CSS defines its own syntax, processing model, and format, initially defined in the 1990s. It requires a custom processor.</p>
    <p>This specification uses the common JSON format, which can be processed by any JSON tools, including web browser contexts, JavaScript, and many other tools.</p>
    <p>This specification attempts to define its rules in a way that CSS might be expresssed in JSON.</p>
    <h4 class="heading settled" data-level="9.2.2" id="css_selectors"><span class="secno">9.2.2. </span><span class="content">CSS selectors</span><a class="self-link" href="#css_selectors"></a></h4>

--- a/index.html
+++ b/index.html
@@ -1491,7 +1491,7 @@ Possible extra rowspan handling
   <meta content="Bikeshed version 742f3d674, updated Mon Nov 4 14:56:54 2024 -0800" name="generator">
   <link href="https://Inclusio-Community.github.io/json-image-metadata/" rel="canonical">
   <link href="./favicon.svg" rel="icon">
-  <meta content="d0e16892b151d9e75d0ef62d638143e5a4b7d004" name="revision">
+  <meta content="39851d252cdb8f5b739cfd6dc987bbcb97c422c6" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>/* Boilerplate: style-autolinks */
 .css.css, .property.property, .descriptor.descriptor {
@@ -2949,7 +2949,7 @@ Parts of this work may be from another specification document.  If so, those par
     <li data-md>
      <p><strong>An element link</strong>: a selector indicating a specific element or set of elements in the DOM of a SVG file;</p>
     <li data-md>
-     <p>**A <code>shape</code> object**: an object that defines a shape to be dynamically represented in the diagram file.</p>
+     <p><strong>A</strong> <code>shape</code> <strong>object</strong>: an object that defines a shape to be dynamically represented in the diagram file.</p>
    </ol>
    <h3 class="heading settled" data-level="5.1" id="region_element_selector"><span class="secno">5.1. </span><span class="content">Region element <code>selector</code></span><a class="self-link" href="#region_element_selector"></a></h3>
    <p>A region may consist of a <code>selector</code> key with a valid selector pointing to one or more elements in the DOM of an SVG file. The target may be a textual element, a shape element, or a container element. If the selector target is a container element, the shape region is all targetable elements within that container, but not the bounding box of the container element itself.</p>

--- a/index.html
+++ b/index.html
@@ -1488,10 +1488,11 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version d5d58a306, updated Fri Jan 26 16:12:28 2024 -0800" name="generator">
+  <meta content="Bikeshed version 742f3d674, updated Mon Nov 4 14:56:54 2024 -0800" name="generator">
   <link href="https://Inclusio-Community.github.io/json-image-metadata/" rel="canonical">
   <link href="./favicon.svg" rel="icon">
-  <meta content="56ea70f30253870d966e09ecd34898fd8380316a" name="revision">
+  <meta content="d0e16892b151d9e75d0ef62d638143e5a4b7d004" name="revision">
+  <meta content="dark light" name="color-scheme">
 <style>/* Boilerplate: style-autolinks */
 .css.css, .property.property, .descriptor.descriptor {
     color: var(--a-normal-text);
@@ -2015,7 +2016,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">JSON Image Metadata</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2024-07-25">25 July 2024</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2024-11-11">11 November 2024</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2029,9 +2030,9 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <div data-fill-with="warning"></div>
    <p class="copyright" data-fill-with="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" height="15" src="https://licensebuttons.net/p/zero/1.0/80x15.png" width="80"></a> To the extent possible under law, the editors have waived all copyright
 and related or neighboring rights to this work.
-In addition, as of 25 July 2024,
-the editors have made this specification available under the <a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
-which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
+In addition, as of 11 November 2024,
+the editors have made this specification available under the <a href="https://www.openwebfoundation.org/the-agreements/the-owf-1-0-agreements-granted-claims/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
+which is available at https://www.openwebfoundation.org/the-agreements/the-owf-1-0-agreements-granted-claims/owfa-1-0.
 Parts of this work may be from another specification document.  If so, those parts are instead covered by the license of that specification document. </p>
    <hr title="Separator for header">
   </div>
@@ -2260,8 +2261,8 @@ Parts of this work may be from another specification document.  If so, those par
    <h3 class="heading settled" data-level="2.1" id="interoperability"><span class="secno">2.1. </span><span class="content">Interoperability</span><a class="self-link" href="#interoperability"></a></h3>
    <p>This specification should be complete and definitive with the state of the art, to prevent the need for additional or competing specifications that would decrease interoperability.</p>
    <h3 class="heading settled" data-level="2.2" id="personalization"><span class="secno">2.2. </span><span class="content">Personalization</span><a class="self-link" href="#personalization"></a></h3>
-   <p>This assistive technology must enable the user to select which of the available accomodations are enabled at any time, and at which available effect level. This must be able to set as a default in the user agent, and must be overrideable by the user to meet their specific need at any time.</p>
-   <p>Any given end-user might have multiple disabilities, with varying degrees of effect at any given time; any given document might have multiple accomodations enabled and encoded in it; any given user agent might suport multiple assistive technologies; any given environment might have different affordances and constraints.</p>
+   <p>This assistive technology must enable the user to select which of the available accommodations are enabled at any time, and at which available effect level. This must be able to set as a default in the user agent, and must be overrideable by the user to meet their specific need at any time.</p>
+   <p>Any given end-user might have multiple disabilities, with varying degrees of effect at any given time; any given document might have multiple accommodations enabled and encoded in it; any given user agent might suport multiple assistive technologies; any given environment might have different affordances and constraints.</p>
    <div class="example" id="xmp_low_vision_high_contrast"><a class="self-link" href="#xmp_low_vision_high_contrast"></a> A low vision user might wish to enable very high contrast in a bright environment or when they are tired, and lower contrast when they are in a more moderately lighted environment and well-rested. </div>
    <div class="example" id="xmp_blind_env_conditions"><a class="self-link" href="#xmp_blind_env_conditions"></a> A blind user might wish to enable haptics and braille output when they are in a quiet zone or noisy environment, and sonification and spoken output when they are in a private, quiet environment. </div>
    <h3 class="heading settled" data-level="2.3" id="security"><span class="secno">2.3. </span><span class="content">Security</span><a class="self-link" href="#security"></a></h3>
@@ -2281,9 +2282,9 @@ Parts of this work may be from another specification document.  If so, those par
    <p>This specification should be able to define the full range of expression for any assistive technology technique. The current version should detail parameters for haptics, sonification, tactiles, high contrast, voicing, and braille, and should be extensible to accomodate other techniques in the future.</p>
    <p>At the same time, this specification should establish defaults and baselines based on best practices, wherever possible, to encourage good authoring and normalize user experience.</p>
    <h3 class="heading settled" data-level="2.9" id="searching_categorization"><span class="secno">2.9. </span><span class="content">Searching and categorization</span><a class="self-link" href="#searching_categorization"></a></h3>
-   <p>This specification must define easy ways to enable the distribution and discovery of content based on user needs and accomodation provided in the document. One way to do this is to provide a standardized way to express keyword tags, ratings, and capabilities within the document itself.</p>
+   <p>This specification must define easy ways to enable the distribution and discovery of content based on user needs and accommodation provided in the document. One way to do this is to provide a standardized way to express keyword tags, ratings, and capabilities within the document itself.</p>
    <h3 class="heading settled" data-level="2.10" id="provenance_expression"><span class="secno">2.10. </span><span class="content">Provenance expression</span><a class="self-link" href="#provenance_expression"></a></h3>
-   <p>Where, when, and by whom an image was created is often very important information, not least because it can enable the user to find more cotent by any given author, or to verify the quality of the source. It can also provide a "provenance chain", where content that has been adapted to specific needs beyond its original publisher can be shared, while also providing credit to the original author or publisher.</p>
+   <p>Where, when, and by whom an image was created is often very important information, not least because it can enable the user to find more content by any given author, or to verify the quality of the source. It can also provide a "provenance chain", where content that has been adapted to specific needs beyond its original publisher can be shared, while also providing credit to the original author or publisher.</p>
    <h3 class="heading settled" data-level="2.11" id="encapsulation"><span class="secno">2.11. </span><span class="content">Encapsulation</span><a class="self-link" href="#encapsulation"></a></h3>
    <p>Through encapsulation, more than one metadata profile can be included for any given image document, much like a stylesheet can change the appearance of the same HMTL file. This specification should not require any changes to the markup of SVG or other files, with 2 exceptions:</p>
    <ol>
@@ -2303,7 +2304,7 @@ Parts of this work may be from another specification document.  If so, those par
    <h3 class="heading settled" data-level="3.1" id="mime_type"><span class="secno">3.1. </span><span class="content">JIM MIME type</span><a class="self-link" href="#mime_type"></a></h3>
    <p>The MIME type for a JSON Image Metadata document is <code>text/jim+json</code>.</p>
    <h3 class="heading settled" data-level="3.2" id="conform_doc"><span class="secno">3.2. </span><span class="content">Conforming document</span><a class="self-link" href="#conform_doc"></a></h3>
-   <p>A document conforming to this specification must contain a metadata block that matches the schema defined in this specification, and must have at least one non-empty <code>datasets</code> block or one non-empty <code>behavior</code> block.</p>
+   <p>A document conforming to this specification must contain a metadata block that matches the schema defined in this specification, and must have at least one non-empty <code>datasets</code> block or one non-empty <code>behaviors</code> block.</p>
    <p>This specification assumes the format of the metadata is in a JSON object. Other conforming serializations are possible, such as XML or a binary format, as long as they adhere to the structure of the defined JSON schema, and can be serialized as JSON.</p>
    <p>A conforming document must provide a means to discover the metadata block.</p>
    <h4 class="heading settled" data-level="3.2.1" id="conform_doc_svg"><span class="secno">3.2.1. </span><span class="content">Conforming SVG document</span><a class="self-link" href="#conform_doc_svg"></a></h4>
@@ -2379,7 +2380,7 @@ Parts of this work may be from another specification document.  If so, those par
    <h5 class="heading settled" data-level="4.1.2.1" id="structured_data"><span class="secno">4.1.2.1. </span><span class="content">Structured data</span><a class="self-link" href="#structured_data"></a></h5>
    <p>Structured data includes faceted data, whether qualitative or quantitative, that can be represented by a chart or graph.</p>
    <p>This data must be included in objects in the <code>facets</code> and <code>series</code> keys.</p>
-   <p class="note" role="note"><span class="marker">Note:</span> A future version of this specification will define schamata for a canonical dataset structure or set of structures for different types of data visualization.</p>
+   <p class="note" role="note"><span class="marker">Note:</span> A future version of this specification will define schemata for a canonical dataset structure or set of structures for different types of data visualization.</p>
    <h5 class="heading settled" data-level="4.1.2.2" id="unstructured_data"><span class="secno">4.1.2.2. </span><span class="content">Unstructured data</span><a class="self-link" href="#unstructured_data"></a></h5>
    <p>Unstructured data includes many types of diagrams, illustrations, pictorial graphics, or infographics. There may be some informal structure to such graphics, including hierarchies such as section headings, but they are not formatted in a defined manner.</p>
    <p>Labels, descriptions, and other unstructured metadata may optionally be included in objects in the <code>items</code> key.</p>
@@ -2714,7 +2715,7 @@ Parts of this work may be from another specification document.  If so, those par
 <c- p>}</c->
 </pre>
    <h3 class="heading settled" data-level="4.4" id="behaviors"><span class="secno">4.4. </span><span class="content">Behaviors</span><a class="self-link" href="#behaviors"></a></h3>
-   <p>An <code>behavior</code> block is an array with the key <code>behavior</code>, which contains one or more ojects including at least a target (defined by the <code>region</code> key), and an event type containing one or more of the behaviors, including <code>haptic</code>, <code>audio</code>, <code>sonification</code>, <code>announcement</code>, <code>contrast</code>, and <code>tactile</code>.</p>
+   <p>A <code>behaviors</code> block is an array with the key <code>behaviors</code>, which contains one or more objects including at least a target (defined by the <code>region</code> key), and an event type containing one or more of the behaviors, including <code>haptic</code>, <code>audio</code>, <code>sonification</code>, <code>announcement</code>, <code>contrast</code>, and <code>tactile</code>.</p>
    <h4 class="heading settled" data-level="4.4.1" id="behavior_generators"><span class="secno">4.4.1. </span><span class="content">Behavior and conforming generators</span><a class="self-link" href="#behavior_generators"></a></h4>
    <p>A generator conforming to this specification is not required to add behaviors to graphics, only a dataset and selectors.</p>
    <p class="note" role="note"><span class="marker">Note:</span> While this specification does not define best practices for different behaviors for different classes of user agent and graphics, a companion best practices document is under development. A conforming generator might be much more useful if it also follows that guidance and generates graphic documents with behaviors optimized for the target user agent capabilities.</p>
@@ -2872,10 +2873,10 @@ Parts of this work may be from another specification document.  If so, those par
    <p>A <code>provenance</code> block is an object with the key <code>provenance</code>.</p>
 <pre class="highlight"><c- p>{</c->
   <c- f>"provenance"</c-><c- p>:</c-> <c- p>{</c->
-    <c- f>"notes"</c-><c- p>:</c-> <c- p>{</c->
+    <c- f>"notes"</c-><c- p>:</c-> <c- p>[</c->
       <c- u>"item 1"</c-><c- p>,</c->
       <c- u>"item 2"</c->
-    <c- p>}</c->
+    <c- p>]</c->
   <c- p>}</c->
 <c- p>}</c->
 </pre>
@@ -2909,7 +2910,7 @@ Parts of this work may be from another specification document.  If so, those par
 </pre>
    <h4 class="heading settled" data-level="4.6.2" id="capabilities_ratings"><span class="secno">4.6.2. </span><span class="content">Capabilities and ratings</span><a class="self-link" href="#capabilities_ratings"></a></h4>
    <div class="note" role="note"> <b>Note:</b> This is a rough notion of how we might define </div>
-   <p>The <code>capabilities</code> key denotes an object that includes which accomodations have been defined in the image document, and some system of rating that scores the effectiveness of that accomodation.</p>
+   <p>The <code>capabilities</code> key denotes an object that includes which accommodations have been defined in the image document, and some system of rating that scores the effectiveness of that accommodation.</p>
    <p>Each capability defines an array of capability instances, each of which consists of a least a condition of applicability, and a rating.</p>
 <pre class="highlight"><c- p>{</c->
   <c- f>"capabilities"</c-><c- p>:</c-> <c- p>{</c->
@@ -2939,7 +2940,7 @@ Parts of this work may be from another specification document.  If so, those par
   <c- p>}</c->
 <c- p>}</c->  
 </pre>
-   <div class="note" role="note"> <b>Note:</b> Consider splitting out capabilities and ratings into seperate entries. </div>
+   <div class="note" role="note"> <b>Note:</b> Consider splitting out capabilities and ratings into separate entries. </div>
    <div class="note" role="note"> <b>Note:</b> To be defined further. </div>
    <h2 class="heading settled" data-level="5" id="regions"><span class="secno">5. </span><span class="content">Regions</span><a class="self-link" href="#regions"></a></h2>
    <p>A region is an area of an diagram image that is associated with a particular behavior.</p>
@@ -3031,7 +3032,7 @@ Similar to your implementation, there will indeed be the ability to draw “invi
       <td>The second parameter is an integer representing a time in milliseconds before the vibration duration array begins repeating. If the value is <code>0</code> or a positive integer, the haptic pattern must repeat until the activating behavior is terminated (such as by the user moving their finger off the target region). If the value is a negative integer, or if the value is omitted, the haptic pattern must not repeat.
      <tr>
       <th>repetition index
-      <td>The third parameter is an integer indicating the index of the vibration duration array that is the starting duraction for repetiion, if any. If the value is <code>0</code> or a positive integer, each repetition of the haptic pattern must start at the indicated index and continue to the end of vibration duration array. If the value is a negative integer, or if the value is omitted, the haptic pattern must start at the <code>0</code> index. Repetition must only occur according to the value of the repetition interval.
+      <td>The third parameter is an integer indicating the index of the vibration duration array that is the starting duration for repetition, if any. If the value is <code>0</code> or a positive integer, each repetition of the haptic pattern must start at the indicated index and continue to the end of vibration duration array. If the value is a negative integer, or if the value is omitted, the haptic pattern must start at the <code>0</code> index. Repetition must only occur according to the value of the repetition interval.
    </table>
    <div class="example" id="xmp_haptic_pattern_simple">
     <a class="self-link" href="#xmp_haptic_pattern_simple"></a> A simple haptic pattern that will trigger a single vibration lasting 200 milliseconds. 
@@ -3392,7 +3393,7 @@ Similar to your implementation, there will indeed be the ability to draw “invi
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
    <dt id="biblio-json-schema">[JSON-Schema]
-   <dd>Austin Wright; et al. <a href="https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema"><cite>JSON Schema: A Media Type for Describing JSON Documents</cite></a>. 8 December 2020. Internet-Draft. URL: <a href="https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema">https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema</a>
+   <dd>Austin Wright; et al. <a href="https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema"><cite>JSON Schema: A Media Type for Describing JSON Documents</cite></a>. 10 June 2022. Internet-Draft. URL: <a href="https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema">https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema</a>
    <dt id="biblio-jsonpath">[JSONPath]
    <dd>S. Gössner; G. Normington; C. Bormann. <a href="https://www.rfc-editor.org/rfc/rfc9535"><cite>JSONPath: Query expressions for JSON</cite></a>. Internet-Draft. URL: <a href="https://www.rfc-editor.org/rfc/rfc9535">https://www.rfc-editor.org/rfc/rfc9535</a>
    <dt id="biblio-selectors-4">[Selectors-4]

--- a/index.html
+++ b/index.html
@@ -1491,7 +1491,7 @@ Possible extra rowspan handling
   <meta content="Bikeshed version 742f3d674, updated Mon Nov 4 14:56:54 2024 -0800" name="generator">
   <link href="https://Inclusio-Community.github.io/json-image-metadata/" rel="canonical">
   <link href="./favicon.svg" rel="icon">
-  <meta content="39851d252cdb8f5b739cfd6dc987bbcb97c422c6" name="revision">
+  <meta content="e75f2917735f228c446d17bd871e43062007ea35" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>/* Boilerplate: style-autolinks */
 .css.css, .property.property, .descriptor.descriptor {


### PR DESCRIPTION
This PR fixes some typos and formatting in the spec. The HTML spec has been updated using Bikeshed.