### PR TITLE
Changed `datasets/*/items` to be an object

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -323,8 +323,8 @@ These entities include the `title`, `subtitle`, `description`, `representation`,
     </tr>
     <tr>
       <td>`items`</td>
-      <td>array</td>
-      <td>A loosely organized set of items for unstructured data, such as labels, values, and descriptions for diagrams</td>
+      <td>object</td>
+      <td>A loosely organized collection of items for unstructured data, such as labels, values, and descriptions for diagrams</td>
       <td>optional</td>
     </tr>
     <tr>
@@ -636,7 +636,7 @@ The `series` array contains one or more objects, each of which contains one or m
 
 #### The `items` key #### {#items_data_block}
 
-A loosely organized set of items for unstructured data, such as labels, values, and descriptions for diagrams.
+A loosely organized collection of items for unstructured data, such as labels, values, and descriptions for diagrams.
 
 TODO: describe the `items` object
 


### PR DESCRIPTION
This PR changes `datasets/*/items` to be an object, rather than an array.

An object seems more useful here, as it allows users to specify what kind of item each item is. For example, Exemplar 007 Map of Netherlands specifies its items as countries, cities, compass points etc.

Closes #47