### PR TITLE
Added missing measure fields to bar chart example

### DIFF
--- a/examples/versioned/0.3.2/E001-Vertical_Bar_Chart-0_3_2.svg
+++ b/examples/versioned/0.3.2/E001-Vertical_Bar_Chart-0_3_2.svg
@@ -44,12 +44,14 @@
             "x": {
               "label": "Time (Days)",
               "variableType": "independent",
-              "labelType": "x axis"
+              "labelType": "x axis",
+              "measure": "interval"
             },
             "y": {
               "label": "Recorded Temperatures",
               "variableType": "dependent",
-              "labelType": "y axis"
+              "labelType": "y axis",
+              "measure": "ratio"
             }
           },
           "series": [


### PR DESCRIPTION
This PR adds the `datasets[0].facets/*/measure` fields which are in the spec but were missing in this example.